### PR TITLE
Testing repository classes

### DIFF
--- a/ContactTracing15.Services/AppDbContextFactory .cs
+++ b/ContactTracing15.Services/AppDbContextFactory .cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ContactTracing15.Services
+{
+    public class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbContext>
+    {
+            public AppDbContext CreateDbContext(string[] args)
+            {
+                var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
+                optionsBuilder.UseSqlServer(
+                  "Server=(localdb)\\mssqllocaldb;Database=EFSample.Testing;Trusted_Connection=True;");
+
+                return new AppDbContext(optionsBuilder.Options);
+            }
+    }
+}

--- a/ContactTracing15.Services/Migrations/20210325033319_spGetById.cs
+++ b/ContactTracing15.Services/Migrations/20210325033319_spGetById.cs
@@ -50,7 +50,7 @@ namespace ContactTracing15.Services.Migrations
                                     @TracingCentreId int
                                     as
                                     Begin
-                                        Select * from TracingCentress
+                                        Select * from TracingCentres
                                         where TracingCentreId = @TracingCentreId
                                     End";
             migrationBuilder.Sql(procedureTracingCentres);

--- a/ContactTracing15.ServicesTests1/ContactTracing15.ServicesTests1.csproj
+++ b/ContactTracing15.ServicesTests1/ContactTracing15.ServicesTests1.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>.NETCoreApp,Version=v3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ContactTracing15.Services\ContactTracing15.Services.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ContactTracing15.ServicesTests1/IntegrationSetUp.cs
+++ b/ContactTracing15.ServicesTests1/IntegrationSetUp.cs
@@ -13,6 +13,8 @@ namespace ContactTracing15.ServicesTests1
         public async Task SetUp()
         {
             var dbContextFactory = new AppDbContextFactory();
+            
+
             using (var dbContext = dbContextFactory.CreateDbContext(new string[] { }))
             {
                 await dbContext.Database.EnsureDeletedAsync();

--- a/ContactTracing15.ServicesTests1/IntegrationSetUp.cs
+++ b/ContactTracing15.ServicesTests1/IntegrationSetUp.cs
@@ -1,0 +1,23 @@
+﻿using ContactTracing15.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ContactTracing15.ServicesTests1
+{
+    public class IntegrationSetUp
+    {
+        [ClassInitialize]
+        public async Task SetUp()
+        {
+            var dbContextFactory = new AppDbContextFactory();
+            using (var dbContext = dbContextFactory.CreateDbContext(new string[] { }))
+            {
+                await dbContext.Database.EnsureDeletedAsync();
+                await dbContext.Database.EnsureCreatedAsync();
+            }
+        }
+    }
+}

--- a/ContactTracing15.ServicesTests1/IntegrationTestBase.cs
+++ b/ContactTracing15.ServicesTests1/IntegrationTestBase.cs
@@ -1,0 +1,29 @@
+﻿using ContactTracing15.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ContactTracing15.ServicesTests1
+{
+    public abstract class IntegrationTestBase
+    {
+            protected AppDbContext dbContext = null!;
+
+            [TestInitialize]
+            public void SetUp()
+            {
+                var dbContextFactory = new AppDbContextFactory();
+                dbContext = dbContextFactory.CreateDbContext(new string[] { });
+            }
+
+            [TestCleanup]
+            public void TearDown()
+            {
+                if (dbContext != null)
+                {
+                    dbContext.Dispose();
+                }
+            }
+        }
+}

--- a/ContactTracing15.ServicesTests1/IntegrationTestBase.cs
+++ b/ContactTracing15.ServicesTests1/IntegrationTestBase.cs
@@ -1,4 +1,5 @@
-﻿using ContactTracing15.Services;
+﻿using ContactTracing15.Models;
+using ContactTracing15.Services;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -16,6 +17,13 @@ namespace ContactTracing15.ServicesTests1
         protected SQLTracerRepository tracerRepository;
         protected SQLTracingCentreRepository tracingCentreRepository;
 
+        protected Case case1;
+        protected Contact contact1;
+        protected Tester tester1;
+        protected TestingCentre testingCentre1;
+        protected Tracer tracer1;
+        protected TracingCentre tracingCentre1;
+
 
         [TestInitialize]
         public void SetUp()
@@ -28,9 +36,86 @@ namespace ContactTracing15.ServicesTests1
             testingCentreRepository = new SQLTestingCentreRepository(dbContext);
             tracerRepository = new SQLTracerRepository(dbContext);
             tracingCentreRepository = new SQLTracingCentreRepository(dbContext);
-            
 
+            MakeCase1();
+            MakeContact1();
+            MakeTester1();
+            MakeTestingCentre1();
+            MakeTracer1();
+            MakeTracingCentre1();
+
+            
+        }       
+
+        private void MakeCase1()
+        {
+            case1 = new Case
+            {
+                AddedDate = new DateTime(3, 3, 3, 3, 3, 3, 3),
+                TestDate = new DateTime(4, 4, 4, 4, 4, 4, 4),
+                Forename = "John",
+                Surname = "Doe",
+                Phone = "+0123456789",
+                Postcode = "AB12",
+                Traced = false,
+                TracerID = 1
+            };
         }
+
+        private void MakeContact1()
+        {
+            contact1 = new Contact
+            {
+                Forename = "Jane",
+                Surname = "Doe",
+                CaseID = 1,
+                Email = "jane.doe@email.com",
+                AddedDate = new DateTime(2021, 3, 30),
+                Phone = "0123456789",
+                TracedDate = new DateTime(2021, 3, 31)
+            };
+        }
+
+        private void MakeTester1()
+        {
+            tester1 = new Tester
+            {
+                Username = "Test_Username",
+                //TODO: investigate robustness of hard-coding ID values
+                TestingCentreID = 1
+            };
+        }
+
+        private void MakeTestingCentre1()
+        {
+            testingCentre1 = new TestingCentre
+            {
+                Name = "Test_Testing_Centre",
+                //testingCentre1.RegistrationCode = 123456;
+                Postcode = "AB12 CDE"
+                //TODO: investigate robustness of hard-coding ID values
+                
+            };
+        }
+
+        private void MakeTracer1()
+        {
+            tracer1 = new Tracer
+            {
+                Username = "Sally_Tracer",
+                TracingCentreID = 1
+            };
+        }
+
+        private void MakeTracingCentre1()
+        {
+            tracingCentre1 = new TracingCentre
+            {
+                Name = "Tracing Centre #1",
+                Postcode = "FG34 HIJ"
+            };
+        }
+
 
         [TestCleanup]
         public void TearDown()

--- a/ContactTracing15.ServicesTests1/IntegrationTestBase.cs
+++ b/ContactTracing15.ServicesTests1/IntegrationTestBase.cs
@@ -8,22 +8,37 @@ namespace ContactTracing15.ServicesTests1
 {
     public abstract class IntegrationTestBase
     {
-            protected AppDbContext dbContext = null!;
+        protected AppDbContext dbContext = null!;
+        protected SQLCaseRepository caseRepository;
+        protected SQLContactRepository contactRepository;
+        protected SQLTesterRepository testerRepository;
+        protected SQLTestingCentreRepository testingCentreRepository;
+        protected SQLTracerRepository tracerRepository;
+        protected SQLTracingCentreRepository tracingCentreRepository;
 
-            [TestInitialize]
-            public void SetUp()
-            {
-                var dbContextFactory = new AppDbContextFactory();
-                dbContext = dbContextFactory.CreateDbContext(new string[] { });
-            }
 
-            [TestCleanup]
-            public void TearDown()
+        [TestInitialize]
+        public void SetUp()
+        {
+            var dbContextFactory = new AppDbContextFactory();
+            dbContext = dbContextFactory.CreateDbContext(new string[] { });
+            caseRepository = new SQLCaseRepository(dbContext);
+            contactRepository = new SQLContactRepository(dbContext);
+            testerRepository = new SQLTesterRepository(dbContext);
+            testingCentreRepository = new SQLTestingCentreRepository(dbContext);
+            tracerRepository = new SQLTracerRepository(dbContext);
+            tracingCentreRepository = new SQLTracingCentreRepository(dbContext);
+            
+
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            if (dbContext != null)
             {
-                if (dbContext != null)
-                {
-                    dbContext.Dispose();
-                }
+                dbContext.Dispose();
             }
         }
+    }
 }

--- a/ContactTracing15.ServicesTests1/IntegrationTestBase.cs
+++ b/ContactTracing15.ServicesTests1/IntegrationTestBase.cs
@@ -57,8 +57,7 @@ namespace ContactTracing15.ServicesTests1
                 Surname = "Doe",
                 Phone = "+0123456789",
                 Postcode = "AB12",
-                Traced = false,
-                TracerID = 1
+                Traced = false
             };
         }
 

--- a/ContactTracing15.ServicesTests1/SQLCaseRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLCaseRepositoryTests.cs
@@ -22,21 +22,15 @@ namespace ContactTracing15.Services.Tests
         [TestMethod()]
         public void AddTest()
         {
-            SQLTestingCentreRepository testingCentreRepository = new SQLTestingCentreRepository(dbContext);
             TestingCentre testCentre = new TestingCentre();
             testCentre.Name = "Centre #1";
-
             testingCentreRepository.Add(testCentre);
+ 
 
-
-
-            SQLTesterRepository testerRepository = new SQLTesterRepository(dbContext);
             Tester tester = new Tester();
             tester.Username = "testing_user1";
             tester.TestingCentre = testCentre;
             testerRepository.Add(tester);
-
-            SQLCaseRepository caseRepository = new SQLCaseRepository(dbContext); 
 
             Case case1 = new Case();
             case1.AddedDate = new DateTime(3, 3, 3, 3, 3, 3, 3);

--- a/ContactTracing15.ServicesTests1/SQLCaseRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLCaseRepositoryTests.cs
@@ -5,66 +5,100 @@ using System.Collections.Generic;
 using System.Text;
 using ContactTracing15.ServicesTests1;
 using ContactTracing15.Models;
+using System.Linq;
 
 namespace ContactTracing15.Services.Tests
 {
     [TestClass()]
     public class SQLCaseRepositoryTests : IntegrationTestBase
     {
-        [TestMethod()]
-        public void AddTest()
-        {
 
+        [TestInitialize()]
+        public void SetUpTests()
+        {
             testingCentreRepository.Add(testingCentre1);
 
+            int testingCentreID = testingCentreRepository.GetAllTestingCentres().First().TestingCentreID;
+            tester1.TestingCentreID = testingCentreID;
             testerRepository.Add(tester1);
 
-            
+            int testerID = testerRepository.GetAllTesters().First().TesterID;
+            case1.TesterID = testerID;
+
+        }
+
+
+        [TestMethod()]
+        public void A10_AddTest()
+        {
 
             caseRepository.Add(case1);
+            IEnumerable<Case> allCases = caseRepository.GetAllCases();
+            Boolean caseFound = false;
 
-            Case caseFromDb = caseRepository.GetCase(1);
-
-            Assert.AreEqual(caseFromDb.Forename, case1.Forename);
-            Assert.AreEqual(caseFromDb.Surname, case1.Surname);
-            Assert.AreEqual(caseFromDb.Traced , case1.Traced);
-
+            foreach (Case caseFromDb in allCases)
+            {
+                if (caseFromDb.Forename == case1.Forename && caseFromDb.Surname == case1.Surname)
+                {
+                    caseFound = true;
+                }
+            }
+            Assert.IsTrue(caseFound, "Case not found in the database after supposed addition");
         }
 
         [TestMethod()]
-        public void DeleteTest()
+        public void A50_DeleteTest()
         {
-            Assert.Fail();
+            IEnumerable<Case> allCases = caseRepository.GetAllCases();
+
+            List<int> idList = new List<int>();
+
+            foreach (Case caseFromDb in allCases)
+            {
+                int id = caseFromDb.CaseID;
+                idList.Add(id);
+            }
+            foreach (int id in idList)
+            {
+                caseRepository.Delete(id);
+            }
+
+            Assert.AreEqual(caseRepository.GetAllCases().Count(), 0);
         }
 
         [TestMethod()]
-        public void GetAllCasesTest()
+        public void A20_GetAllCasesTest()
         {
-            Assert.Fail();
+            IEnumerable<Case> allCases = caseRepository.GetAllCases();
+            Assert.IsTrue(allCases.Count() > 0, "Non-zero number of cases in the table");
+            //Assert.AreEqual(allTesters.First().Name, case1.Name);
         }
 
         [TestMethod()]
-        public void GetCaseTest()
+        public void A30_GetCaseTest()
         {
-            Assert.Fail();
+            IEnumerable<Case> allCases = caseRepository.GetAllCases();
+            Case baseCase = allCases.First();
+
+            Console.WriteLine(baseCase.CaseID);
+
+            Case caseFromDb = caseRepository.GetCase(baseCase.CaseID);
+            Assert.AreEqual(baseCase.Forename, caseFromDb.Forename);
+            Assert.AreEqual(baseCase.Surname, caseFromDb.Surname);
+            Assert.AreEqual(baseCase.AddedDate, caseFromDb.AddedDate);
         }
 
         [TestMethod()]
-        public void SearchTest()
+        public void A40_UpdateTest()
         {
-            Assert.Fail();
-        }
+            IEnumerable<Case> allCases = caseRepository.GetAllCases();
+            Case baseCase = allCases.First();
+            baseCase.Forename = "Updated Jane";
+            caseRepository.Update(baseCase);
 
-        [TestMethod()]
-        public void UpdateTest()
-        {
-            Assert.Fail();
-        }
+            Case caseFromDb2 = caseRepository.GetCase(baseCase.CaseID);
 
-        [TestMethod()]
-        public void SaveTest()
-        {
-            Assert.Fail();
+            Assert.AreEqual(baseCase.Forename, caseFromDb2.Forename);
         }
     }
 }

--- a/ContactTracing15.ServicesTests1/SQLCaseRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLCaseRepositoryTests.cs
@@ -11,36 +11,15 @@ namespace ContactTracing15.Services.Tests
     [TestClass()]
     public class SQLCaseRepositoryTests : IntegrationTestBase
     {
-
-        [TestMethod()]
-        public void SQLCaseRepositoryTest()
-        {
-
-            Assert.Fail();
-        }
-
         [TestMethod()]
         public void AddTest()
         {
-            TestingCentre testCentre = new TestingCentre();
-            testCentre.Name = "Centre #1";
-            testingCentreRepository.Add(testCentre);
- 
 
-            Tester tester = new Tester();
-            tester.Username = "testing_user1";
-            tester.TestingCentre = testCentre;
-            testerRepository.Add(tester);
+            testingCentreRepository.Add(testingCentre1);
 
-            Case case1 = new Case();
-            case1.AddedDate = new DateTime(3, 3, 3, 3, 3, 3, 3);
-            case1.TestDate = new DateTime(4, 4, 4, 4, 4, 4, 4);
-            case1.Forename = "John";
-            case1.Surname = "Doe";
-            case1.Phone = "+0123456789";
-            case1.Postcode = "AB12";
-            case1.Traced = false;
-            case1.TracerID = 1;
+            testerRepository.Add(tester1);
+
+            
 
             caseRepository.Add(case1);
 

--- a/ContactTracing15.ServicesTests1/SQLCaseRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLCaseRepositoryTests.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ContactTracing15.Services;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using ContactTracing15.ServicesTests1;
+using ContactTracing15.Models;
+
+namespace ContactTracing15.Services.Tests
+{
+    [TestClass()]
+    public class SQLCaseRepositoryTests : IntegrationTestBase
+    {
+
+        [TestMethod()]
+        public void SQLCaseRepositoryTest()
+        {
+
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void AddTest()
+        {
+            SQLTestingCentreRepository testingCentreRepository = new SQLTestingCentreRepository(dbContext);
+            TestingCentre testCentre = new TestingCentre();
+            testCentre.Name = "Centre #1";
+
+            testingCentreRepository.Add(testCentre);
+
+
+
+            SQLTesterRepository testerRepository = new SQLTesterRepository(dbContext);
+            Tester tester = new Tester();
+            tester.Username = "testing_user1";
+            tester.TestingCentre = testCentre;
+            testerRepository.Add(tester);
+
+            SQLCaseRepository caseRepository = new SQLCaseRepository(dbContext); 
+
+            Case case1 = new Case();
+            case1.AddedDate = new DateTime(3, 3, 3, 3, 3, 3, 3);
+            case1.TestDate = new DateTime(4, 4, 4, 4, 4, 4, 4);
+            case1.Forename = "John";
+            case1.Surname = "Doe";
+            case1.Phone = "+0123456789";
+            case1.Postcode = "AB12";
+            case1.Traced = false;
+            case1.TracerID = 1;
+
+            caseRepository.Add(case1);
+
+            Case caseFromDb = caseRepository.GetCase(1);
+
+            Assert.AreEqual(caseFromDb.Forename, case1.Forename);
+            Assert.AreEqual(caseFromDb.Surname, case1.Surname);
+            Assert.AreEqual(caseFromDb.Traced , case1.Traced);
+
+        }
+
+        [TestMethod()]
+        public void DeleteTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void GetAllCasesTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void GetCaseTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void SearchTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void UpdateTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void SaveTest()
+        {
+            Assert.Fail();
+        }
+    }
+}

--- a/ContactTracing15.ServicesTests1/SQLContactRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLContactRepositoryTests.cs
@@ -3,58 +3,106 @@ using ContactTracing15.Services;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using ContactTracing15.ServicesTests1;
+using System.Linq;
+using ContactTracing15.Models;
 
 namespace ContactTracing15.Services.Tests
 {
     [TestClass()]
-    public class SQLContactRepositoryTests
+    public class SQLContactRepositoryTests : IntegrationTestBase
     {
-        [TestMethod()]
-        public void SQLContactRepositoryTest()
+        [TestInitialize()]
+        public void SetUpTests()
         {
-            Assert.Fail();
+            testingCentreRepository.Add(testingCentre1);
+
+            int testingCentreID = testingCentreRepository.GetAllTestingCentres().First().TestingCentreID;
+            tester1.TestingCentreID = testingCentreID;
+            testerRepository.Add(tester1);
+
+            int testerID = testerRepository.GetAllTesters().First().TesterID;
+            case1.TesterID = testerID;
+            caseRepository.Add(case1);
+
+            int caseID = caseRepository.GetAllCases().First().CaseID;
+            contact1.CaseID = caseID;
+
+
+
         }
 
         [TestMethod()]
-        public void AddTest()
+        public void A10_AddTest()
         {
-            Assert.Fail();
+            contactRepository.Add(contact1);
+            IEnumerable<Contact> allContacts = contactRepository.GetAllContacts();
+            Boolean contactFound = false;
+
+            foreach (Contact contactFromDb in allContacts)
+            {
+                if (contactFromDb.Forename == contact1.Forename && contactFromDb.Surname == contact1.Surname)
+                {
+                    contactFound = true;
+                }
+            }
+            Assert.IsTrue(contactFound, "Contact not found in the database after supposed addition");
+
         }
 
         [TestMethod()]
-        public void DeleteTest()
+        public void A50_DeleteTest()
         {
-            Assert.Fail();
+            IEnumerable<Contact> allContacts = contactRepository.GetAllContacts();
+
+            List<int> idList = new List<int>();
+
+            foreach (Contact contactFromDb in allContacts)
+            {
+                int id = contactFromDb.ContactID;
+                idList.Add(id);
+            }
+            foreach (int id in idList)
+            {
+                contactRepository.Delete(id);
+            }
+
+            Assert.AreEqual(contactRepository.GetAllContacts().Count(), 0);
         }
 
         [TestMethod()]
-        public void GetAllContactsTest()
+        public void A20_GetAllContactsTest()
         {
-            Assert.Fail();
+            IEnumerable<Contact> allContacts = contactRepository.GetAllContacts();
+            Assert.IsTrue(allContacts.Count() > 0, "Non-zero number of contacts in the table");
+            //Assert.AreEqual(allTesters.First().Name, contact1.Name);
         }
 
         [TestMethod()]
-        public void GetContactTest()
+        public void A30_GetContactTest()
         {
-            Assert.Fail();
+            IEnumerable<Contact> allContacts = contactRepository.GetAllContacts();
+            Contact baseContact = allContacts.First();
+
+            Console.WriteLine(baseContact.ContactID);
+
+            Contact contactFromDb = contactRepository.GetContact(baseContact.ContactID);
+            Assert.AreEqual(baseContact.Forename, contactFromDb.Forename);
+            Assert.AreEqual(baseContact.Surname, contactFromDb.Surname);
+            Assert.AreEqual(baseContact.AddedDate, contactFromDb.AddedDate);
         }
 
         [TestMethod()]
-        public void SearchTest()
+        public void A40_UpdateTest()
         {
-            Assert.Fail();
-        }
+            IEnumerable<Contact> allContacts = contactRepository.GetAllContacts();
+            Contact baseContact = allContacts.First();
+            baseContact.Forename = "Updated John";
+            contactRepository.Update(baseContact);
 
-        [TestMethod()]
-        public void UpdateTest()
-        {
-            Assert.Fail();
-        }
+            Contact contactFromDb2 = contactRepository.GetContact(baseContact.ContactID);
 
-        [TestMethod()]
-        public void SaveTest()
-        {
-            Assert.Fail();
+            Assert.AreEqual(baseContact.Forename, contactFromDb2.Forename);
         }
     }
 }

--- a/ContactTracing15.ServicesTests1/SQLContactRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLContactRepositoryTests.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ContactTracing15.Services;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ContactTracing15.Services.Tests
+{
+    [TestClass()]
+    public class SQLContactRepositoryTests
+    {
+        [TestMethod()]
+        public void SQLContactRepositoryTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void AddTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void DeleteTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void GetAllContactsTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void GetContactTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void SearchTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void UpdateTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void SaveTest()
+        {
+            Assert.Fail();
+        }
+    }
+}

--- a/ContactTracing15.ServicesTests1/SQLTesterRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLTesterRepositoryTests.cs
@@ -4,58 +4,93 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using ContactTracing15.ServicesTests1;
+using System.Linq;
+using ContactTracing15.Models;
 
 namespace ContactTracing15.Services.Tests
 {
     [TestClass()]
     public class SQLTesterRepositoryTests : IntegrationTestBase
     {
-        [TestMethod()]
-        public void SQLTesterRepositoryTest()
+        [TestInitialize()]
+        public void SetUpTests()
         {
-            Assert.Fail();
+            testingCentreRepository.Add(testingCentre1);
+
+            int testingCentreID = testingCentreRepository.GetAllTestingCentres().First().TestingCentreID;
+            tester1.TestingCentreID = testingCentreID;
+
         }
 
         [TestMethod()]
-        public void AddTest()
+        public void A10_AddTest()
         {
-            Assert.Fail();
+            testerRepository.Add(tester1);
+            IEnumerable<Tester> allTesters = testerRepository.GetAllTesters();
+            Boolean testerFound = false;
+
+            foreach (Tester testerFromDb in allTesters)
+            {
+                if (testerFromDb.Username == tester1.Username)
+                {
+                    testerFound = true;
+                }
+            }
+            Assert.IsTrue(testerFound, "Tester not found in the database after supposed addition");
         }
 
         [TestMethod()]
-        public void DeleteTest()
+        public void A50_DeleteTest()
         {
-            Assert.Fail();
+            IEnumerable<Tester> allTesters = testerRepository.GetAllTesters();
+
+            List<int> idList = new List<int>();
+
+            foreach (Tester testerFromDb in allTesters)
+            {
+                int id = testerFromDb.TesterID;
+                idList.Add(id);
+            }
+            foreach (int id in idList)
+            {
+                testerRepository.Delete(id);
+            }
+
+            Assert.AreEqual(testerRepository.GetAllTesters().Count(), 0);
         }
 
         [TestMethod()]
-        public void GetAllTestersTest()
+        public void A20_GetAllTestersTest()
         {
-            Assert.Fail();
+            IEnumerable<Tester> allTesters = testerRepository.GetAllTesters();
+            Assert.IsTrue(allTesters.Count() > 0, "Non-zero number of testers in the table");
+            //Assert.AreEqual(allTesters.First().Name, tester1.Name);
         }
 
         [TestMethod()]
-        public void GetTesterTest()
+        public void A30_GetTesterTest()
         {
-            Assert.Fail();
+            IEnumerable<Tester> allTesters = testerRepository.GetAllTesters();
+            Tester baseTester = allTesters.First();
+
+            Console.WriteLine(baseTester.TestingCentreID);
+
+            Tester testerFromDb = testerRepository.GetTester(baseTester.TesterID);
+            Assert.AreEqual(baseTester.Username, testerFromDb.Username);
         }
 
         [TestMethod()]
-        public void SearchTest()
+        public void A40_UpdateTest()
         {
-            Assert.Fail();
+            IEnumerable<Tester> allTesters = testerRepository.GetAllTesters();
+            Tester baseTester = allTesters.First();
+            baseTester.Username = "Updated Username";
+            testerRepository.Update(baseTester);
+
+            Tester testerFromDb2 = testerRepository.GetTester(baseTester.TesterID);
+
+            Assert.AreEqual(baseTester.Username, testerFromDb2.Username);
         }
 
-        [TestMethod()]
-        public void UpdateTest()
-        {
-            Assert.Fail();
-        }
-
-        [TestMethod()]
-        public void SaveTest()
-        {
-            Assert.Fail();
-        }
     }
 }

--- a/ContactTracing15.ServicesTests1/SQLTesterRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLTesterRepositoryTests.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ContactTracing15.Services;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using ContactTracing15.ServicesTests1;
+
+namespace ContactTracing15.Services.Tests
+{
+    [TestClass()]
+    public class SQLTesterRepositoryTests : IntegrationTestBase
+    {
+        [TestMethod()]
+        public void SQLTesterRepositoryTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void AddTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void DeleteTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void GetAllTestersTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void GetTesterTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void SearchTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void UpdateTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void SaveTest()
+        {
+            Assert.Fail();
+        }
+    }
+}

--- a/ContactTracing15.ServicesTests1/SQLTestingCentreRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLTestingCentreRepositoryTests.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ContactTracing15.Services;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using ContactTracing15.ServicesTests1;
+
+namespace ContactTracing15.Services.Tests
+{
+    [TestClass()]
+    public class SQLTestingCentreRepositoryTests : IntegrationTestBase
+    {
+        [TestMethod()]
+        public void SQLTestingCentreRepositoryTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void AddTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void DeleteTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void GetAllTestingCentresTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void GetTestingCentreTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void UpdateTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void SaveTest()
+        {
+            Assert.Fail();
+        }
+    }
+}

--- a/ContactTracing15.ServicesTests1/SQLTestingCentreRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLTestingCentreRepositoryTests.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using ContactTracing15.ServicesTests1;
+using ContactTracing15.Models;
+using System.Linq;
 
 namespace ContactTracing15.Services.Tests
 {
@@ -19,7 +21,17 @@ namespace ContactTracing15.Services.Tests
         [TestMethod()]
         public void AddTest()
         {
-            Assert.Fail();
+
+            TestingCentre testCentre = new TestingCentre();
+            testCentre.Name = "Centre #1";
+            testingCentreRepository.Add(testCentre);
+
+
+            IEnumerable<TestingCentre> allCentres = testingCentreRepository.GetAllTestingCentres();
+
+            TestingCentre centreFromDb = allCentres.First();
+            Assert.AreEqual(testCentre.Name, centreFromDb.Name);
+
         }
 
         [TestMethod()]

--- a/ContactTracing15.ServicesTests1/SQLTestingCentreRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLTestingCentreRepositoryTests.cs
@@ -12,56 +12,77 @@ namespace ContactTracing15.Services.Tests
     [TestClass()]
     public class SQLTestingCentreRepositoryTests : IntegrationTestBase
     {
+
         [TestMethod()]
-        public void SQLTestingCentreRepositoryTest()
+        public void A10_AddTest()
         {
-            Assert.Fail();
+            testingCentreRepository.Add(testingCentre1);
+            IEnumerable<TestingCentre> allCentres = testingCentreRepository.GetAllTestingCentres();
+            Boolean centreFound = false;
+
+            foreach (TestingCentre centreFromDb in allCentres)
+            {
+                if (centreFromDb.Name == testingCentre1.Name)
+                {
+                    centreFound = true;
+                }
+            }
+            Assert.IsTrue(centreFound, "Testing centre not found in the database after supposed addition");
+
         }
-
         [TestMethod()]
-        public void AddTest()
+        public void A20_GetAllTestingCentresTest()
         {
-
-            TestingCentre testCentre = new TestingCentre();
-            testCentre.Name = "Centre #1";
-            testingCentreRepository.Add(testCentre);
-
 
             IEnumerable<TestingCentre> allCentres = testingCentreRepository.GetAllTestingCentres();
-
-            TestingCentre centreFromDb = allCentres.First();
-            Assert.AreEqual(testCentre.Name, centreFromDb.Name);
+            Assert.IsTrue(allCentres.Count() > 0, "Non-zero number of centres in the table");
+            //Assert.AreEqual(allCentres.First().Name, testingCentre1.Name);
 
         }
 
         [TestMethod()]
-        public void DeleteTest()
+        public void A30_GetTestingCentreTest()
         {
-            Assert.Fail();
+            IEnumerable<TestingCentre> allCentres = testingCentreRepository.GetAllTestingCentres();
+            TestingCentre baseCentre = allCentres.First();
+
+            TestingCentre centreFromDb = testingCentreRepository.GetTestingCentre(baseCentre.TestingCentreID);
+            Assert.AreEqual(baseCentre.Name, centreFromDb.Name);
+
+        }        
+
+        [TestMethod()]
+        public void A40_UpdateTest()
+        {
+            IEnumerable<TestingCentre> allCentres = testingCentreRepository.GetAllTestingCentres();
+            TestingCentre baseCentre = allCentres.First();
+            baseCentre.Name = "Updated Name";
+            testingCentreRepository.Update(baseCentre);
+
+            TestingCentre centreFromDb2 = testingCentreRepository.GetTestingCentre(baseCentre.TestingCentreID);
+
+            Assert.AreEqual(baseCentre.Name, centreFromDb2.Name);
         }
 
         [TestMethod()]
-        public void GetAllTestingCentresTest()
+        public void A50_DeleteTest()
         {
-            Assert.Fail();
-        }
+            IEnumerable<TestingCentre> allCentres = testingCentreRepository.GetAllTestingCentres();
 
-        [TestMethod()]
-        public void GetTestingCentreTest()
-        {
-            Assert.Fail();
-        }
+            List<int> idList = new List<int>();
 
-        [TestMethod()]
-        public void UpdateTest()
-        {
-            Assert.Fail();
-        }
+            foreach (TestingCentre centreFromDb in allCentres)
+            {
+                int id = centreFromDb.TestingCentreID;
+                idList.Add(id);
+            }
+            foreach (int id in idList)
+            {
+                testingCentreRepository.Delete(id);
+            }
+       
+            Assert.AreEqual(testingCentreRepository.GetAllTestingCentres().Count(), 0);
 
-        [TestMethod()]
-        public void SaveTest()
-        {
-            Assert.Fail();
         }
     }
 }

--- a/ContactTracing15.ServicesTests1/SQLTracerRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLTracerRepositoryTests.cs
@@ -48,7 +48,7 @@ namespace ContactTracing15.Services.Tests
 
             foreach (Tracer tracerFromDb in allTracers)
             {
-                int id = tracerFromDb.TracingCentreID;
+                int id = tracerFromDb.TracerID;
                 idList.Add(id);
             }
             foreach (int id in idList)
@@ -63,8 +63,8 @@ namespace ContactTracing15.Services.Tests
         public void A20_GetAllTracersTest()
         {
             IEnumerable<Tracer> allTracers = tracerRepository.GetAllTracers();
-            Assert.IsTrue(allTracers.Count() > 0, "Non-zero number of centres in the table");
-            //Assert.AreEqual(allCentres.First().Name, tracer1.Name);
+            Assert.IsTrue(allTracers.Count() > 0, "Non-zero number of tracers in the table");
+            //Assert.AreEqual(allTesters.First().Name, tracer1.Name);
         }
 
         [TestMethod()]
@@ -77,12 +77,6 @@ namespace ContactTracing15.Services.Tests
 
             Tracer tracerFromDb = tracerRepository.GetTracer(baseTracer.TracerID);
             Assert.AreEqual(baseTracer.Username, tracerFromDb.Username);
-        }
-
-        [TestMethod()]
-        public void A50_SearchTest()
-        {
-            Assert.Fail();
         }
 
         [TestMethod()]

--- a/ContactTracing15.ServicesTests1/SQLTracerRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLTracerRepositoryTests.cs
@@ -10,11 +10,6 @@ namespace ContactTracing15.Services.Tests
     [TestClass()]
     public class SQLTracerRepositoryTests : IntegrationTestBase
     {
-        [TestMethod()]
-        public void SQLTracerRepositoryTest()
-        {
-            Assert.Fail();
-        }
 
         [TestMethod()]
         public void AddTest()

--- a/ContactTracing15.ServicesTests1/SQLTracerRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLTracerRepositoryTests.cs
@@ -4,53 +4,99 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using ContactTracing15.ServicesTests1;
+using System.Linq;
+using ContactTracing15.Models;
 
 namespace ContactTracing15.Services.Tests
 {
     [TestClass()]
     public class SQLTracerRepositoryTests : IntegrationTestBase
     {
+        [TestInitialize()]
+        public void SetUpTests()
+        {
+            tracingCentreRepository.Add(tracingCentre1);
+
+            int tracingCentreID = tracingCentreRepository.GetAllTracingCentres().First().TracingCentreID;
+            tracer1.TracingCentreID = tracingCentreID;
+
+        }
 
         [TestMethod()]
-        public void AddTest()
+        public void A10_AddTest()
+        {
+            tracerRepository.Add(tracer1);
+            IEnumerable<Tracer> allTracers = tracerRepository.GetAllTracers();
+            Boolean tracerFound = false;
+
+            foreach (Tracer tracerFromDb in allTracers)
+            {
+                if (tracerFromDb.Username == tracer1.Username)
+                {
+                    tracerFound = true;
+                }
+            }
+            Assert.IsTrue(tracerFound, "Tracer not found in the database after supposed addition");
+        }
+
+        [TestMethod()]
+        public void A60_DeleteTest()
+        {
+            IEnumerable<Tracer> allTracers = tracerRepository.GetAllTracers();
+
+            List<int> idList = new List<int>();
+
+            foreach (Tracer tracerFromDb in allTracers)
+            {
+                int id = tracerFromDb.TracingCentreID;
+                idList.Add(id);
+            }
+            foreach (int id in idList)
+            {
+                tracerRepository.Delete(id);
+            }
+
+            Assert.AreEqual(tracerRepository.GetAllTracers().Count(), 0);
+        }
+
+        [TestMethod()]
+        public void A20_GetAllTracersTest()
+        {
+            IEnumerable<Tracer> allTracers = tracerRepository.GetAllTracers();
+            Assert.IsTrue(allTracers.Count() > 0, "Non-zero number of centres in the table");
+            //Assert.AreEqual(allCentres.First().Name, tracer1.Name);
+        }
+
+        [TestMethod()]
+        public void A30_GetTracerTest()
+        {
+            IEnumerable<Tracer> allTracers = tracerRepository.GetAllTracers();
+            Tracer baseTracer = allTracers.First();
+
+            Console.WriteLine(baseTracer.TracingCentreID);
+
+            Tracer tracerFromDb = tracerRepository.GetTracer(baseTracer.TracerID);
+            Assert.AreEqual(baseTracer.Username, tracerFromDb.Username);
+        }
+
+        [TestMethod()]
+        public void A50_SearchTest()
         {
             Assert.Fail();
         }
 
         [TestMethod()]
-        public void DeleteTest()
+        public void A40_UpdateTest()
         {
-            Assert.Fail();
+            IEnumerable<Tracer> allTracers = tracerRepository.GetAllTracers();
+            Tracer baseTracer = allTracers.First();
+            baseTracer.Username = "Updated Username";
+            tracerRepository.Update(baseTracer);
+
+            Tracer tracerFromDb2 = tracerRepository.GetTracer(baseTracer.TracerID);
+
+            Assert.AreEqual(baseTracer.Username, tracerFromDb2.Username);
         }
 
-        [TestMethod()]
-        public void GetAllTracersTest()
-        {
-            Assert.Fail();
-        }
-
-        [TestMethod()]
-        public void GetTracerTest()
-        {
-            Assert.Fail();
-        }
-
-        [TestMethod()]
-        public void SearchTest()
-        {
-            Assert.Fail();
-        }
-
-        [TestMethod()]
-        public void UpdateTest()
-        {
-            Assert.Fail();
-        }
-
-        [TestMethod()]
-        public void SaveTest()
-        {
-            Assert.Fail();
-        }
     }
 }

--- a/ContactTracing15.ServicesTests1/SQLTracerRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLTracerRepositoryTests.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ContactTracing15.Services;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using ContactTracing15.ServicesTests1;
+
+namespace ContactTracing15.Services.Tests
+{
+    [TestClass()]
+    public class SQLTracerRepositoryTests : IntegrationTestBase
+    {
+        [TestMethod()]
+        public void SQLTracerRepositoryTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void AddTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void DeleteTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void GetAllTracersTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void GetTracerTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void SearchTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void UpdateTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void SaveTest()
+        {
+            Assert.Fail();
+        }
+    }
+}

--- a/ContactTracing15.ServicesTests1/SQLTracingCentreRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLTracingCentreRepositoryTests.cs
@@ -4,52 +4,83 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using ContactTracing15.ServicesTests1;
+using ContactTracing15.Models;
+using System.Linq;
 
 namespace ContactTracing15.Services.Tests
 {
     [TestClass()]
     public class SQLTracingCentreRepositoryTests :  IntegrationTestBase
     {
+
         [TestMethod()]
-        public void SQLTracingCentreRepositoryTest()
+        public void A10_AddTest()
         {
-            Assert.Fail();
+            tracingCentreRepository.Add(tracingCentre1);
+            IEnumerable<TracingCentre> allCentres = tracingCentreRepository.GetAllTracingCentres();
+            Boolean centreFound = false;
+
+            foreach (TracingCentre centreFromDb in allCentres)
+            {
+                if (centreFromDb.Name == tracingCentre1.Name)
+                {
+                    centreFound = true;
+                }
+            }
+            Assert.IsTrue(centreFound, "Testing centre not found in the database after supposed addition");
         }
 
         [TestMethod()]
-        public void AddTest()
+        public void A50_DeleteTest()
         {
-            Assert.Fail();
+            IEnumerable<TracingCentre> allCentres = tracingCentreRepository.GetAllTracingCentres();
+
+            List<int> idList = new List<int>();
+
+            foreach (TracingCentre centreFromDb in allCentres)
+            {
+                int id = centreFromDb.TracingCentreID;
+                idList.Add(id);
+            }
+            foreach (int id in idList)
+            {
+                tracingCentreRepository.Delete(id);
+            }
+
+            Assert.AreEqual(tracingCentreRepository.GetAllTracingCentres().Count(), 0);
         }
 
         [TestMethod()]
-        public void DeleteTest()
+        public void A20_GetAllTracingCentresTest()
         {
-            Assert.Fail();
+            IEnumerable<TracingCentre> allCentres = tracingCentreRepository.GetAllTracingCentres();
+            Assert.IsTrue(allCentres.Count() > 0, "Non-zero number of centres in the table");
+            //Assert.AreEqual(allCentres.First().Name, tracingCentre1.Name);
         }
 
         [TestMethod()]
-        public void GetAllTracingCentresTest()
+        public void A30_GetTracingCentreTest()
         {
-            Assert.Fail();
+            IEnumerable<TracingCentre> allCentres = tracingCentreRepository.GetAllTracingCentres();
+            TracingCentre baseCentre = allCentres.First();
+
+            Console.WriteLine(baseCentre.TracingCentreID);
+
+            TracingCentre centreFromDb = tracingCentreRepository.GetTracingCentre(baseCentre.TracingCentreID);
+            Assert.AreEqual(baseCentre.Name, centreFromDb.Name);
         }
 
         [TestMethod()]
-        public void GetTracingCentreTest()
+        public void A40_UpdateTest()
         {
-            Assert.Fail();
-        }
+            IEnumerable<TracingCentre> allCentres = tracingCentreRepository.GetAllTracingCentres();
+            TracingCentre baseCentre = allCentres.First();
+            baseCentre.Name = "Updated Name";
+            tracingCentreRepository.Update(baseCentre);
 
-        [TestMethod()]
-        public void UpdateTest()
-        {
-            Assert.Fail();
-        }
+            TracingCentre centreFromDb2 = tracingCentreRepository.GetTracingCentre(baseCentre.TracingCentreID);
 
-        [TestMethod()]
-        public void SaveTest()
-        {
-            Assert.Fail();
+            Assert.AreEqual(baseCentre.Name, centreFromDb2.Name);
         }
     }
 }

--- a/ContactTracing15.ServicesTests1/SQLTracingCentreRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLTracingCentreRepositoryTests.cs
@@ -27,7 +27,7 @@ namespace ContactTracing15.Services.Tests
                     centreFound = true;
                 }
             }
-            Assert.IsTrue(centreFound, "Testing centre not found in the database after supposed addition");
+            Assert.IsTrue(centreFound, "Tracing centre not found in the database after supposed addition");
         }
 
         [TestMethod()]

--- a/ContactTracing15.ServicesTests1/SQLTracingCentreRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLTracingCentreRepositoryTests.cs
@@ -64,8 +64,6 @@ namespace ContactTracing15.Services.Tests
             IEnumerable<TracingCentre> allCentres = tracingCentreRepository.GetAllTracingCentres();
             TracingCentre baseCentre = allCentres.First();
 
-            Console.WriteLine(baseCentre.TracingCentreID);
-
             TracingCentre centreFromDb = tracingCentreRepository.GetTracingCentre(baseCentre.TracingCentreID);
             Assert.AreEqual(baseCentre.Name, centreFromDb.Name);
         }

--- a/ContactTracing15.ServicesTests1/SQLTracingCentreRepositoryTests.cs
+++ b/ContactTracing15.ServicesTests1/SQLTracingCentreRepositoryTests.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ContactTracing15.Services;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using ContactTracing15.ServicesTests1;
+
+namespace ContactTracing15.Services.Tests
+{
+    [TestClass()]
+    public class SQLTracingCentreRepositoryTests :  IntegrationTestBase
+    {
+        [TestMethod()]
+        public void SQLTracingCentreRepositoryTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void AddTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void DeleteTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void GetAllTracingCentresTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void GetTracingCentreTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void UpdateTest()
+        {
+            Assert.Fail();
+        }
+
+        [TestMethod()]
+        public void SaveTest()
+        {
+            Assert.Fail();
+        }
+    }
+}

--- a/ContactTracing15.sln
+++ b/ContactTracing15.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ContactTracing15.Models", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ContactTracing15.Services", "ContactTracing15.Services\ContactTracing15.Services.csproj", "{5A66D0FF-541C-4E82-BB25-90E8DC540A52}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ContactTracing15.ServicesTests1", "ContactTracing15.ServicesTests1\ContactTracing15.ServicesTests1.csproj", "{6ECD77C8-A4D9-46AE-8CED-4613E9C4B0B4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{5A66D0FF-541C-4E82-BB25-90E8DC540A52}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5A66D0FF-541C-4E82-BB25-90E8DC540A52}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5A66D0FF-541C-4E82-BB25-90E8DC540A52}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6ECD77C8-A4D9-46AE-8CED-4613E9C4B0B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6ECD77C8-A4D9-46AE-8CED-4613E9C4B0B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6ECD77C8-A4D9-46AE-8CED-4613E9C4B0B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6ECD77C8-A4D9-46AE-8CED-4613E9C4B0B4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ContactTracing15/Update Database.txt
+++ b/ContactTracing15/Update Database.txt
@@ -1,3 +1,3 @@
 ﻿To make database run locally, open Package Manager Console, make sure that "default project" is set to
-services and run command
+services and run command. Note: default project is a button to press, not a parameter (sorry Dima!)
 > Update-Database -Context AppDbContext

--- a/ContactTracing15/Update Database.txt
+++ b/ContactTracing15/Update Database.txt
@@ -1,3 +1,3 @@
-﻿To make database run locally, open Package Manager Console, make sure that "default project" is set to
-services and run command. Note: default project is a button to press, not a parameter (sorry Dima!)
+﻿To make database run locally & to create/maintain a testing database, open Package Manager Console, make sure that "default project" is set to
+services and run command. Note: default project is a button to press, not a parameter to pass (sorry Dima!).
 > Update-Database -Context AppDbContext


### PR DESCRIPTION
I have added tests for the repository classes. These tests use a localdb instance, so before running the tests follow the instructions left by Dima in the UpdateDatabase.txt file.

Tests within a single class should be run in numerical order (i.e. A10, then A20 etc...) - this is because data created by earlier tests is needed for later tests (dependency between tests is unfortunately unavoidable in a CRUD situation like this).

Issue with migrations was caught and the bug was squashed.